### PR TITLE
Update extract_path Unit Tests

### DIFF
--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -16,10 +16,12 @@ class TestScriptRunnable
 
   attr_accessor :script, :last_reply
 
+  # maps fixture ids to server ids
   def id_map
     @id_map ||= {}
   end 
 
+  # maps operation.responseid to responses
   def response_map
     @response_map ||= {}
   end 
@@ -126,7 +128,10 @@ class TestScriptRunnable
       request_type = REQUEST_TYPES[op.local_method || op.type.code]
       throw :exit, report.skip('notImplemented') unless request_type
 
-      request = [request_type, extract_path(op), extract_body(request_type, op), extract_headers(op)]
+      path = extract_path(op, request_type)
+      throw :exit, report.fail('unknownFailure') unless path
+
+      request = [request_type, path, extract_body(request_type, op), extract_headers(op)]
       request.compact!
 
       begin
@@ -168,30 +173,30 @@ class TestScriptRunnable
     report.pass
   end
   
-  def extract_path op
-    return replace_variables(op.url) if op.url
-    pieces = { format: FORMAT_MAP[op.contentType] }
-
-    if op.targetId
-      pieces[:id] = id_map[op.targetId]
-      pieces[:resource] = find_resource(op.targetId).resourceType
-
-      throw :exit, report.fail('noId') unless pieces[:id]
-      throw :exit, report.fail('noTargetIdFixture') unless pieces[:resource]
-    elsif op.params
-      pieces[:resource] = replace_variables op.resource
-      pieces[:params] = replace_variables op.params
-
-      throw :exit, report.fail('noResource') unless pieces[:resource]
-    elsif op.sourceId
-      pieces[:resource] = find_resource(op.sourceId).resourceType
-
-      throw :exit, report.fail('noSourceFixture') unless fixtures[op.sourceId].resourceType
+  def extract_path(operation, request_type)
+    binding.pry
+    return replace_variables(operation.url) if operation.url
+    if operation.params
+      return if operation.resource.nil? and requires_type(operation)
+      mime = "{&_format=#{FORMAT_MAP[operation.contentType]}}" if operation.contentType
+      params = "#{replace_variables(operation.params)}#{mime}"
+      search = "/_search" if request_type == :post
+      return "#{operation.resource}#{search}#{params}"
+    elsif operation.targetId
+      type = response_map[operation.targetId]&.resource.resourceType
+      id = id_map[operation.targetId]
+      return "#{type}/#{id}" unless (type.nil? || id.nil?) 
+    elsif operation.sourceId
+      return fixtures[operation.sourceId]&.resourceType
     end
-
-    # TODO: requestEncodeUrl?
-    client.resource_url(pieces)
   end
+
+  # Determines if the operation requires [type] as part of
+  # its intended request url
+  def requires_type operation
+    return !(['search'].include?(operation.type.code))
+  end 
+
 
   def extract_body(request_type, op)
     return unless SENDER_TYPES.include?(request_type)

--- a/spec/extract_path_spec.rb
+++ b/spec/extract_path_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'TestScriptRunnable'
 
 describe TestScriptRunnable do
-  let(:id) { '123' } 
+  let(:id) { '123' }
   let(:req_type) { :get }
   let(:contentType) { 'xml' }
   let(:sourceId) { 'sourceId' }
@@ -13,14 +15,16 @@ describe TestScriptRunnable do
   let(:absolute_url) { 'https://example.com/Patient/123' }
   let(:clientReply) { FHIR::ClientReply.new(nil, nil, client) }
   let(:operation) { FHIR::TestScript::Setup::Action::Operation.new }
-  let(:runnable) { TestScriptRunnable.new FHIR::TestScript.new(
-    {
-      "resourceType": "TestScript",
-      "url": "http://hl7.org/fhir/TestScript/testscript-example-history",
-      "name": "TestScript-Example-History",
-      "status": "draft"
-    }
-  )}
+  let(:runnable) do
+    TestScriptRunnable.new FHIR::TestScript.new(
+      {
+        "resourceType": 'TestScript',
+        "url": 'http://hl7.org/fhir/TestScript/testscript-example-history',
+        "name": 'TestScript-Example-History',
+        "status": 'draft'
+      }
+    )
+  end
 
   describe '#extract_path' do
     context 'with absolute url' do
@@ -29,7 +33,7 @@ describe TestScriptRunnable do
       it 'creates the absolute path' do
         operation.url = absolute_url
         expect(runnable.extract_path(operation, req_type)).to eq(absolute_url)
-      end 
+      end
     end
 
     context 'with relative url' do
@@ -38,8 +42,8 @@ describe TestScriptRunnable do
       it 'creates the relative path' do
         operation.url = relative_url
         expect(runnable.extract_path(operation, req_type)).to eq(relative_url)
-      end 
-    end 
+      end
+    end
 
     context 'with params' do
       before do
@@ -47,57 +51,59 @@ describe TestScriptRunnable do
         operation.resource = resource.resourceType
         allow(runnable).to receive(:replace_variables).and_return(params)
         allow(runnable).to receive(:requires_type).and_return(false)
-      end 
+      end
 
       context 'for GET search' do
         context 'with resource' do
-          it 'creates the /[type][?parameters] path' do 
+          it 'creates the /[type][?parameters] path' do
             expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}#{params}")
-          end 
-        end 
-  
+          end
+        end
+
         context 'without resource' do
           before { operation.resource = nil }
 
-          it 'creates the [?parameters] path' do 
-            expect(runnable.extract_path(operation, req_type)).to eq("#{params}")
-          end 
-        end 
+          it 'creates the [?parameters] path' do
+            expect(runnable.extract_path(operation, req_type)).to eq(params.to_s)
+          end
+        end
 
         context 'with mime-type' do
           before { operation.contentType = contentType }
 
           it 'creates the /[type][?parameters]{&_format=[mime-type]} path' do
-            expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}#{params}{&_format=application/fhir+#{contentType}}")
-          end 
-        end 
-      end 
+            expect(runnable.extract_path(operation, req_type))
+              .to eq("#{resource.resourceType}#{params}{&_format=application/fhir+#{contentType}}")
+          end
+        end
+      end
 
       context 'for POST search' do
         let(:req_type) { :post }
-        
-        context 'with resource' do  
-          it 'creates the [type]/_search[?parameters] path' do 
+
+        context 'with resource' do
+          it 'creates the [type]/_search[?parameters] path' do
             expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}/_search#{params}")
-          end 
-        end 
-  
-        context 'without resource' do         
+          end
+        end
+
+        context 'without resource' do
           before { operation.resource = nil }
 
-          it 'creates the /_search[?parameters] path' do 
+          it 'creates the /_search[?parameters] path' do
             expect(runnable.extract_path(operation, req_type)).to eq("/_search#{params}")
-          end 
-        end 
+          end
+        end
 
         context 'with mime-type' do
           before { operation.contentType = contentType }
 
           it 'creates the [type]/_search[?parameters]{&_format=[mime-type]} path' do
-            expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}/_search#{params}{&_format=application/fhir+#{contentType}}")
-          end 
-        end 
-      end 
+            expect(runnable.extract_path(operation, req_type))
+              .to eq("#{resource.resourceType}/_search#{params}{&_format=application/fhir+#{contentType}}")
+          end
+        end
+      end
 
       context 'with resource type required' do
         before { allow(runnable).to receive(:requires_type).and_return(true) }
@@ -106,7 +112,7 @@ describe TestScriptRunnable do
           it 'returns /_search[?parameters] path' do
             expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}#{params}")
           end
-        end 
+        end
 
         context 'without resource' do
           before { operation.resource = nil }
@@ -114,31 +120,31 @@ describe TestScriptRunnable do
           it 'returns nil' do
             expect(runnable.extract_path(operation, req_type)).to eq(nil)
           end
-        end 
-      end 
-    end 
+        end
+      end
+    end
 
     context 'with targetId' do
       before do
         operation.targetId = targetId
         clientReply.resource = resource
         runnable.response_map[targetId] = clientReply
-      end 
+      end
 
       context 'denoting Resource A' do
         before { runnable.id_map[targetId] = id }
 
         it 'creates path to Resource A' do
           expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}/#{id}")
-        end 
+        end
       end
 
       context 'not denoting some Resource A' do
         it 'returns nil' do
           expect(runnable.extract_path(operation, req_type)).to eq(nil)
-        end 
+        end
       end
-    end 
+    end
 
     context 'with sourceId' do
       before { operation.sourceId = sourceId }
@@ -147,17 +153,17 @@ describe TestScriptRunnable do
         before { runnable.fixtures[sourceId] = resource }
 
         it 'returns path to create Fixture A' do
-          expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}")
-        end 
-      end 
+          expect(runnable.extract_path(operation, req_type)).to eq(resource.resourceType.to_s)
+        end
+      end
 
       context 'not denoting some Fixture A' do
         before { runnable.fixtures[sourceId] = nil }
 
         it 'returns nil' do
           expect(runnable.extract_path(operation, req_type)).to eq(nil)
-        end 
-      end 
-    end 
-  end 
-end 
+        end
+      end
+    end
+  end
+end

--- a/spec/extract_path_spec.rb
+++ b/spec/extract_path_spec.rb
@@ -1,15 +1,18 @@
 require 'TestScriptRunnable'
 
 describe TestScriptRunnable do
+  let(:id) { '123' } 
+  let(:req_type) { :get }
+  let(:contentType) { 'xml' }
+  let(:sourceId) { 'sourceId' }
+  let(:targetId) { 'patient-create' }
+  let(:resource) { FHIR::Patient.new }
   let(:relative_url) { 'Patient/123' }
+  let(:params) { '?_lastUpdated=gt2010-10-01' }
+  let(:client) { FHIR::Client.new(absolute_url) }
   let(:absolute_url) { 'https://example.com/Patient/123' }
-  let(:type_coding) { FHIR::Coding.new({
-    system: 'http://hl7.org/fhir/restful-interaction',
-    code: 'create'
-  })}
-  let(:operation) { FHIR::TestScript::Setup::Action::Operation.new({
-    type: type_coding
-  })}
+  let(:clientReply) { FHIR::ClientReply.new(nil, nil, client) }
+  let(:operation) { FHIR::TestScript::Setup::Action::Operation.new }
   let(:runnable) { TestScriptRunnable.new FHIR::TestScript.new(
     {
       "resourceType": "TestScript",
@@ -20,47 +23,140 @@ describe TestScriptRunnable do
   )}
 
   describe '#extract_path' do
-    context 'with url' do
-      context 'absolute' do
-        before { operation.url = absolute_url }
+    context 'with absolute url' do
+      before { allow(runnable).to receive(:replace_variables).and_return(absolute_url) }
 
-        it 'creates a path that includes absolute url' do
-          result = runnable.extract_path operation
-          expect(result).to eq(absolute_url)
+      it 'creates the absolute path' do
+        operation.url = absolute_url
+        expect(runnable.extract_path(operation, req_type)).to eq(absolute_url)
+      end 
+    end
+
+    context 'with relative url' do
+      before { allow(runnable).to receive(:replace_variables).and_return(relative_url) }
+
+      it 'creates the relative path' do
+        operation.url = relative_url
+        expect(runnable.extract_path(operation, req_type)).to eq(relative_url)
+      end 
+    end 
+
+    context 'with params' do
+      before do
+        operation.params = params
+        operation.resource = resource.resourceType
+        allow(runnable).to receive(:replace_variables).and_return(params)
+        allow(runnable).to receive(:requires_type).and_return(false)
+      end 
+
+      context 'for GET search' do
+        context 'with resource' do
+          it 'creates the /[type][?parameters] path' do 
+            expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}#{params}")
+          end 
         end 
-      end
-      
-      context 'relative' do
-        before { operation.url = relative_url }
+  
+        context 'without resource' do
+          before { operation.resource = nil }
 
-        it 'creates a path that includes relative url' do
-          result = runnable.extract_path operation
-          expect(result).to eq(relative_url)
+          it 'creates the [?parameters] path' do 
+            expect(runnable.extract_path(operation, req_type)).to eq("#{params}")
+          end 
+        end 
+
+        context 'with mime-type' do
+          before { operation.contentType = contentType }
+
+          it 'creates the /[type][?parameters]{&_format=[mime-type]} path' do
+            expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}#{params}{&_format=application/fhir+#{contentType}}")
+          end 
+        end 
+      end 
+
+      context 'for POST search' do
+        let(:req_type) { :post }
+        
+        context 'with resource' do  
+          it 'creates the [type]/_search[?parameters] path' do 
+            expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}/_search#{params}")
+          end 
+        end 
+  
+        context 'without resource' do         
+          before { operation.resource = nil }
+
+          it 'creates the /_search[?parameters] path' do 
+            expect(runnable.extract_path(operation, req_type)).to eq("/_search#{params}")
+          end 
+        end 
+
+        context 'with mime-type' do
+          before { operation.contentType = contentType }
+
+          it 'creates the [type]/_search[?parameters]{&_format=[mime-type]} path' do
+            expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}/_search#{params}{&_format=application/fhir+#{contentType}}")
+          end 
+        end 
+      end 
+
+      context 'with resource type required' do
+        before { allow(runnable).to receive(:requires_type).and_return(true) }
+
+        context 'with resource' do
+          it 'returns /_search[?parameters] path' do
+            expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}#{params}")
+          end
+        end 
+
+        context 'without resource' do
+          before { operation.resource = nil }
+
+          it 'returns nil' do
+            expect(runnable.extract_path(operation, req_type)).to eq(nil)
+          end
         end 
       end 
     end 
 
     context 'with targetId' do
-      before { operation.targetId = 'fixture-patient-create' }
-      # some sort of failure 
-      it 'creates a path with targetId' do
-        result = runnable.extract_path operation
+      before do
+        operation.targetId = targetId
+        clientReply.resource = resource
+        runnable.response_map[targetId] = clientReply
       end 
-  end 
 
-    context 'with params' do
-      before { operation.params = '${createResourceId}' }
-      # some sort of failure 
-      it 'creates a path with targetId' do
-        result = runnable.extract_path operation
-      end 
-    end
+      context 'denoting Resource A' do
+        before { runnable.id_map[targetId] = id }
+
+        it 'creates path to Resource A' do
+          expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}/#{id}")
+        end 
+      end
+
+      context 'not denoting some Resource A' do
+        it 'returns nil' do
+          expect(runnable.extract_path(operation, req_type)).to eq(nil)
+        end 
+      end
+    end 
 
     context 'with sourceId' do
-      before { operation.sourceId = 'fixture-patient-create' }
-      # some sort of failure 
-      it 'creates a path with sourceId' do
-        result = runnable.extract_path operation
+      before { operation.sourceId = sourceId }
+
+      context 'denoting some Fixture A' do
+        before { runnable.fixtures[sourceId] = resource }
+
+        it 'returns path to create Fixture A' do
+          expect(runnable.extract_path(operation, req_type)).to eq("#{resource.resourceType}")
+        end 
+      end 
+
+      context 'not denoting some Fixture A' do
+        before { runnable.fixtures[sourceId] = nil }
+
+        it 'returns nil' do
+          expect(runnable.extract_path(operation, req_type)).to eq(nil)
+        end 
       end 
     end 
   end 


### PR DESCRIPTION
Completed the remaining unit tests for `extract_path` method and also simplified the code. The `:exit` error throw-catch design that is in place for all the methods called in the `execute` method (`extract_path`,` extract_headers`) isn't the best because it limits those methods to the context of `execute`. Instead, reworking them piecemeal to return `nil` rather than throw an error if the path can not be created. Then, `execute` can deal with notifying/printing out messages. Small details, but I think it'll help in the long run with making the engine as flexible as possible -- being able to just get the target url from an operation is definitely useful. 