### PR TITLE
Unit Tests for Storage Method 

### DIFF
--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -236,22 +236,19 @@ class TestScriptRunnable
 
     # should this handle requestId storage? 
 
-  # requestId
-  # responseId
-  # sourceId
-  # targetId --> 
-
-  def storage operation
-    self.reply = client.reply
+  def storage(operation)
+    return unless self.reply = client.reply
     client.reply = nil
-    return unless reply
 
+    # <--- from here ---> 
     request_map[operation.requestId] = reply.request if operation.requestId
     response_map[operation.responseId] = reply.response if operation.responseId
 
-    if reply.request[:method] == :delete and [200, 202, 204].include? reply.response[:code]
-      id_map.delete(id_map.key(reply.request[:path].split('/')[1]))
-      return
+    if operation.targetId
+      if reply.request[:method] == :delete and [200, 202, 204].include? reply.response[:code]
+        id_map.delete(operation.targetId)
+        return
+      end 
     end 
 
     begin
@@ -260,8 +257,8 @@ class TestScriptRunnable
     end 
 
     var = reply.response[:headers]['location']
-    var.slice!(reply.request[:url])
-    server_id = reply.resource&.id || var.split('/')[2] 
+    var&.slice!(reply.request[:url])
+    server_id = reply.resource&.id || var&.split('/')[2] 
 
     id_map[operation.responseId] = server_id if server_id and operation.responseId
     id_map[operation.sourceId] = server_id if server_id and operation.sourceId

--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -233,7 +233,7 @@ class TestScriptRunnable
   end  
 
   def successful? code 
-    return [200, 202, 204].include? code
+    [200, 202, 204].include? code
   end 
 
   def storage(op)
@@ -245,7 +245,7 @@ class TestScriptRunnable
 
     (reply.resource = FHIR.from_contents(reply.response&.[](:body).to_s)) rescue {}
 
-    if op.targetId and reply.request[:method] == :delete and successful?(reply.response[:code])
+    if op.targetId and (reply.request[:method] == :delete) and successful?(reply.response[:code])
       id_map.delete(op.targetId) and return
     end 
 

--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -259,10 +259,10 @@ class TestScriptRunnable
   end 
 
   def find_resource id
-    fixtures[id] || response_map[id]&.response&.[](:body)
+    fixtures[id] || response_map[id]&.[](:body)
   end 
 
-  def replace_variables placeholder
+  def replace_variables placeholder    
     return placeholder unless placeholder&.include? '${'
     replaced = placeholder.clone
 

--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -156,7 +156,7 @@ class TestScriptRunnable
         throw :exit
       end
 
-      storage(client, op)
+      storage(op)
 
       report.pass
     end 
@@ -281,7 +281,7 @@ class TestScriptRunnable
     elsif var.path
       evaluate_path(var.path, find_resource(var.sourceId)) 
     elsif var.headerField
-      headers = response_map[var.sourceId]&.response&.[](:headers)
+      headers = response_map[var.sourceId]&.[](:headers)
       headers&.find { |h, v| h == var.headerField.downcase }&.last
     end || var.defaultValue
   end 

--- a/lib/assertions.rb
+++ b/lib/assertions.rb
@@ -55,7 +55,7 @@ module Assertions
   end 
 
   def assert_content_type assertion
-    header = last_reply.response[:headers]['content-type']
+    header = reply.response[:headers]['content-type']
     raise_exception('[.assert_content_type]', 'noContentType', 'content-type') unless header
 
     value = header.split(';').find { |x| x == assertion.contentType }
@@ -63,7 +63,7 @@ module Assertions
   end
 
   def assert_find_resource(id, location)
-    resource = response_map[id]&.resource || fixtures[id] || last_reply&.resource
+    resource = response_map[id]&.resource || fixtures[id] || reply&.resource
     resource || raise_exception(location, 'noResource', "with id: #{id}" || '')
   end 
 
@@ -80,7 +80,7 @@ module Assertions
   end 
 
   def assert_header_field assertion
-    reply = assertion.sourceId ? response_map[assertion.sourceId] : last_reply
+    reply = assertion.sourceId ? response_map[assertion.sourceId] : reply
     if assertion.direction == 'request'
       header_value = reply.request[:headers][assertion.headerField.downcase]
       prefix = 'Request'
@@ -135,21 +135,21 @@ module Assertions
   end 
 
   def assert_request_method assertion
-    assert_operator(last_reply.request[:method].to_s, assertion.operator, replace_variables(assertion.requestMethod), '[.assert_request_method]')
+    assert_operator(reply.request[:method].to_s, assertion.operator, replace_variables(assertion.requestMethod), '[.assert_request_method]')
   end
 
   def assert_request_url assertion
-    assert_operator(last_reply.request[:url], assertion.operator, replace_variables(assertion.requestURL), '[.assert_request_url]')
+    assert_operator(reply.request[:url], assertion.operator, replace_variables(assertion.requestURL), '[.assert_request_url]')
   end 
 
   def assert_response assertion
-    reply = response_map[assertion.sourceId] || last_reply
+    reply = response_map[assertion.sourceId] || reply
     expected = CODE_MAP[assertion.response]
     assert_operator(reply&.code, assertion.operator, expected, '[.assert_response]')
   end 
 
   def assert_response_code assertion
-    reply = response_map[assertion.sourceId] || last_reply
+    reply = response_map[assertion.sourceId] || reply
     assert_operator(reply&.code&.to_s, assertion.operator, assertion.responseCode, '[.assert_response_code]')
   end 
 
@@ -160,9 +160,9 @@ module Assertions
 
   def assert_validate_profile_id assertion
     uri = script.profile.find { |profile| profile.id == assertion.validateProfileId }.reference
-    response = client.validate(last_reply.response, { profile_uri: uri } )
+    response = client.validate(reply.response, { profile_uri: uri } )
 
-    raise_exception('noValidation', '[.assert_valid_profile_id]', last_reply.resource.resourceType) if response.code.to_s == "201"
+    raise_exception('noValidation', '[.assert_valid_profile_id]', reply.resource.resourceType) if response.code.to_s == "201"
     raise_exception('badValidation', '[.assert_valid_profile_id]', response.code)  if response.code.to_s != "200"
   end 
 

--- a/spec/replace_variables_spec.rb
+++ b/spec/replace_variables_spec.rb
@@ -62,7 +62,7 @@ describe TestScriptRunnable do
   let(:multi_match_input) { "/${#{vname}}/${#{vname}}" }
 
   describe '#replace_variables' do
-    before { runnable.response_map[sourceId] = client_reply }
+    before { runnable.response_map[sourceId] = client_reply.response }
 
     context 'given no placeholder' do
       it 'returns input' do
@@ -136,7 +136,7 @@ describe TestScriptRunnable do
             end
 
             context 'since no response' do
-              before { runnable.response_map[sourceId].response = nil }
+              before { runnable.response_map[sourceId] = nil }
 
               it 'returns replaced default input' do
                 expect(runnable.replace_variables(input)).to eq(default_output)
@@ -144,7 +144,7 @@ describe TestScriptRunnable do
             end
 
             context 'since no response headers' do
-              before { runnable.response_map[sourceId].response[:headers] = nil }
+              before { runnable.response_map[sourceId][:headers] = nil }
 
               it 'returns replaced default input' do
                 expect(runnable.replace_variables(input)).to eq(default_output)
@@ -152,7 +152,7 @@ describe TestScriptRunnable do
             end
 
             context 'since no matching header' do
-              before { runnable.response_map[sourceId].response[:headers] = { 'bad_key' => 'bad_val' } }
+              before { runnable.response_map[sourceId][:headers] = { 'bad_key' => 'bad_val' } }
 
               it 'returns replaced default input' do
                 expect(runnable.replace_variables(input)).to eq(default_output)

--- a/spec/store_response_spec.rb
+++ b/spec/store_response_spec.rb
@@ -1,0 +1,29 @@
+require 'TestScriptRunnable'
+
+describe TestScriptRunnable do
+  let(:requestId) { 'requestId' }
+  let(:client) { FHIR::Client.new 'https://example.com' }
+  let(:resource) { FHIR::AllergyIntolerance.new }
+  let(:resourceResponse) { { :code => 200, :headers => {}, :body => resource.to_json } }
+  let(:resourceReply) { FHIR::ClientReply.new(nil, resourceResponse, client) }
+  let(:nonResourceResponse) { { :code => 200, :headers => {}, :body => 'body' } }
+  let(:nonResourceReply) { FHIR::ClientReply.new(nil, nonResourceResponse, client) }
+  let(:requestType) { :get }
+  let(:operation) { FHIR::TestScript::Setup::Action::Operation.new }
+  let(:runnable) {
+    TestScriptRunnable.new FHIR::TestScript.new(
+      {
+        "resourceType": 'TestScript',
+        "url": 'http://hl7.org/fhir/TestScript/testscript-example-history',
+        "name": 'TestScript-Example-History',
+        "status": 'draft'
+      }
+    )
+  }
+
+  context '#storage' do
+    context 'gives fresh client.reply' do
+
+    end 
+  end 
+end 

--- a/spec/store_response_spec.rb
+++ b/spec/store_response_spec.rb
@@ -1,14 +1,19 @@
 require 'TestScriptRunnable'
 
 describe TestScriptRunnable do
-  let(:requestId) { 'requestId' }
-  let(:client) { FHIR::Client.new 'https://example.com' }
-  let(:resource) { FHIR::AllergyIntolerance.new }
-  let(:resourceResponse) { { :code => 200, :headers => {}, :body => resource.to_json } }
-  let(:resourceReply) { FHIR::ClientReply.new(nil, resourceResponse, client) }
-  let(:nonResourceResponse) { { :code => 200, :headers => {}, :body => 'body' } }
-  let(:nonResourceReply) { FHIR::ClientReply.new(nil, nonResourceResponse, client) }
-  let(:requestType) { :get }
+  # let(:requestId) { 'requestId' }
+  # let(:resource) { FHIR::AllergyIntolerance.new }
+  # let(:resourceResponse) { { :code => 200, :headers => {}, :body => resource.to_json } }
+  # let(:resourceReply) { FHIR::ClientReply.new(nil, resourceResponse, client) }
+  # let(:nonResourceResponse) { { :code => 200, :headers => {}, :body => 'body' } }
+  # let(:nonResourceReply) { FHIR::ClientReply.new(nil, nonResourceResponse, client) }
+  # let(:requestType) { :get }
+    # let(:empty_client_reply) { FHIR::ClientReply.new(nil, nil, client) }
+
+  let(:base_url) { 'https://example.com' }
+  let(:server_id) { 'abcdefgh12345678' }
+  let(:id) { 'some_id' }
+  let(:client) { FHIR::Client.new base_url }
   let(:operation) { FHIR::TestScript::Setup::Action::Operation.new }
   let(:runnable) {
     TestScriptRunnable.new FHIR::TestScript.new(
@@ -20,10 +25,157 @@ describe TestScriptRunnable do
       }
     )
   }
+  let(:request) {
+    { 
+      :method => :get, 
+      :url => base_url, 
+      :path => "Patient/#{server_id}/$everything",
+      :headers => {}, 
+      :payload => nil
+    }
+  }
+  let(:response) { 
+    {
+      :code=>200, 
+      :headers=>{"date"=>"Tue, 21 Jun 2022 13:41:44 GMT", "content-type"=>"application/fhir+json; fhirVersion=4.0; charset=utf-8", "content-length"=>"3162", "connection"=>"keep-alive", "etag"=>"W/\"c07e08c4-2a3a-4293-93ec-6d93688a23f5\"", "last-modified"=>"Tue, 21 Jun 2022 13:05:49 GMT", "location"=>"#{base_url}/Patient/#{server_id}/_history/c07e08c4-2a3a-4293-93ec-6d93688a23f5", "strict-transport-security"=>"max-age=15724800; includeSubDomains"}, 
+      :body=>"{\n  \"id\": \"#{server_id}\",\n  \"active\": true,\n  \"name\": [\n    {\n      \"use\": \"official\",\n      \"family\": \"Chalmers\",\n      \"given\": [\n        \"Peter\",\n        \"James\"\n      ]\n    },\n    {\n      \"use\": \"usual\",\n      \"given\": [\n        \"Jim\"\n      ]\n    },\n    {\n      \"use\": \"maiden\",\n      \"family\": \"Windsor\",\n      \"given\": [\n        \"Peter\",\n        \"James\"\n      ],\n      \"period\": {\n        \"end\": \"2002\"\n      }\n    }\n  ],\n  \"gender\": \"male\",\n  \"birthDate\": \"1974-12-25\",\n  \"deceasedBoolean\": false,\n  \"resourceType\": \"Patient\"\n}" 
+    }
+  }
+  let(:client_reply) { FHIR::ClientReply.new(request, response, client) }
 
   context '#storage' do
-    context 'gives fresh client.reply' do
+    context 'when client.reply == nil' do
+      it 'sets @reply = nil' do
+        runnable.storage(operation)
 
+        expect(runnable.reply).to be(nil)
+      end 
+
+      it 'sets client.reply = nil' do
+        runnable.storage(operation)
+
+        expect(runnable.client.reply).to be(nil)
+      end 
+
+      it 'returns nil' do
+        expect(runnable.storage(operation)).to be(nil)
+      end 
+    end 
+
+    context 'when client.reply != nil' do
+      before { runnable.client.reply = client_reply }
+
+      it 'sets @reply = client.reply' do
+        runnable.storage(operation)
+
+        expect(runnable.reply).to eq(client_reply)
+      end 
+      
+      it 'sets client.reply = nil' do
+        runnable.storage(operation)
+
+        expect(runnable.client.reply).to be(nil)
+      end 
+
+      context 'and requestId != nil' do
+        before { operation.requestId = id }
+
+        it 'updates @request_map' do
+          runnable.storage(operation)
+
+          expect(runnable.request_map[id]).to eq(request)
+        end 
+      end 
+
+      context 'and responseId != nil' do
+        before { operation.responseId = id }
+
+        it 'updates @response_map' do
+          runnable.storage(operation)
+
+          expect(runnable.response_map[id]).to eq(response)
+        end 
+
+        context 'and reply.resource != nil' do
+          it 'updates @id_map using reply.resource.id' do
+            runnable.storage(operation)
+
+            expect(runnable.id_map[id]).to eq(server_id)
+          end
+        end
+  
+        context 'and reply.resource == nil' do
+          before { runnable.client.reply.response[:body] = nil }
+
+          it 'updates @id_map using location header' do
+            runnable.storage(operation)
+
+            expect(runnable.id_map[id]).to eq(server_id)
+          end 
+        end 
+      end 
+
+      context 'and request type == :delete' do
+        before { runnable.client.reply.request[:method] = :delete }
+
+        context 'and status code == `okay`' do
+          before { runnable.client.reply.response[:code] = 202 }
+
+          context 'and id extractable from request.path' do
+
+            context 'with id stored' do
+              before { runnable.id_map[id] = server_id }
+
+              it 'updates @id_map' do
+                runnable.storage(operation)
+  
+                expect(runnable.id_map).to eq({})
+              end 
+            end 
+
+
+            context 'without id stored' do
+              it 'ignores @id_map' do
+
+              end 
+            end 
+          end
+
+          context 'and id not extracted from path' do
+            context 'with reponseId' do
+
+            end 
+
+            it 'prints a warning' do
+
+            end 
+
+            it 'ignores @id_map' do
+
+            end 
+          end
+        end
+
+        context 'and status code != `okay`' do
+          it 'ignores @id_map' do
+
+          end 
+        end
+      end
+
+      context 'and sourceId != nil' do 
+        context 'and reply.resource != nil' do
+          it 'updates @id_map using reply.resource.id' do
+
+          end
+        end
+  
+        context 'and reply.resource == nil' do
+          it 'updates @id_mdap using location header' do
+
+          end 
+        end 
+      end 
     end 
   end 
 end 

--- a/spec/store_response_spec.rb
+++ b/spec/store_response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'TestScriptRunnable'
 
 describe TestScriptRunnable do


### PR DESCRIPTION
The usual drill -- unit tests for storage method as well as some additional functionality/clarifications for the method i.e. deleting an ID mapping should be done using the targetId attribute in the operation. 