### PR TITLE
Show validation details on console if TestScript is not valid

### DIFF
--- a/lib/TestScriptEngine.rb
+++ b/lib/TestScriptEngine.rb
@@ -52,6 +52,7 @@ class TestScriptEngine
           FHIR.logger.info "[.load_scripts] TestScript with id [#{script.id}] loaded."
         else
           FHIR.logger.info "[.load_scripts] Invalid or non-TestScript detected. Skipping resource at #{resource}."
+          FHIR.logger.info "[.load_scripts] Violation: #{script.validate.to_hash}"
         end 
       rescue
         FHIR.logger.info "[.load_scripts] Unable to deserialize TestScript resource at #{resource}."


### PR DESCRIPTION
Show validation details on console if TestScript is not valid.
Used .validate()

Example:

`I, [2022-06-29T10:27:38.342288 #94207]  INFO -- : [.load_scripts] Violation: {"url"=>["TestScript.url: invalid cardinality. Found 0 expected 1..1"]}`