### PR TITLE
Add filename as arguments of driver.rb

### DIFF
--- a/lib/TestScriptEngine.rb
+++ b/lib/TestScriptEngine.rb
@@ -3,7 +3,7 @@ require 'fhir_client'
 require_relative './TestScriptRunnable'
 
 class TestScriptEngine
-  attr_accessor :endpoint, :directory_path
+  attr_accessor :endpoint, :directory_path, :file_name
 
   def scripts
     @scripts ||= {}
@@ -25,9 +25,10 @@ class TestScriptEngine
     @client ||= FHIR::Client.new(endpoint || 'localhost:3000') 
   end 
 
-  def initialize(endpoint = nil, directory_path = nil)
+  def initialize(endpoint = nil, directory_path = nil, file_name = nil)
     self.endpoint = endpoint
     self.directory_path = directory_path
+    self.file_name = file_name
   end
 
   # TODO: Tie-in stronger validation. Possibly, Inferno validator.
@@ -37,9 +38,9 @@ class TestScriptEngine
 
   # @path [String] Optional, specifies the path to the folder containing the 
   #                TestScript Resources to-be loaded into the engine. 
-  def load_scripts path = nil, file_name = nil
-    on_deck = Dir.glob "#{path || root}/**/*.{json, xml}"
-    FHIR.logger.info "[.load_scripts] TestScript Path: [#{path || root}]"
+  def load_scripts 
+    on_deck = Dir.glob "#{root}/**/*.{json, xml}"
+    FHIR.logger.info "[.load_scripts] TestScript Path: [#{root}]"
 
     on_deck.each do |resource|
       next if file_name && !resource.include?(file_name)

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -3,25 +3,26 @@ require_relative './TestScriptEngine'
 require './TestScriptRunnable' # TODO: Remove
 
 test_server_url = 'http://hapi.fhir.org/baseR4'
-testscript_path = nil
+testscript_path = '../TestScripts'
+testscript_file = nil
 
 parameters = ARGV
 parameters.each do |parameter|
   if parameter.start_with?('http')
     test_server_url = parameter
+  elsif parameter.include?('.json')
+    testscript_file = parameter
   else
     testscript_path = parameter
   end
 end
 
 puts "SERVER: #{test_server_url}"
-puts "TESTSCRIPTS: #{testscript_path}"
+puts "TESTSCRIPT PATH: #{testscript_path}"
+puts "TESTSCRIPT FILE: #{testscript_file}"
 
-default_engine = TestScriptEngine.new(test_server_url, testscript_path)
-# Load and execute all TestScript in /TestScripts
+default_engine = TestScriptEngine.new(test_server_url, testscript_path, testscript_file)
 default_engine.load_scripts
-# Specify a TestScript to execute
-# default_engine.load_scripts(nil, 'general_test_script.json')
 default_engine.make_runnables
 default_engine.execute_runnables
 default_engine.write_reports


### PR DESCRIPTION
Added TestScript file name as another argument of driver.rb. It would simply driver.rb and load_scripts method in TestScriptEngine.

Example: 
ruby driver.rb general_test_script.json (path can be ignored)