### PR TITLE
Workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/ruby.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/ruby.yml
@@ -1,0 +1,56 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [ '2.7.3' ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+  test: 
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [ '2.7.3' ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rspec
+  
+  # lint:
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       ruby-version: ['2.7.3']
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Ruby
+  #     uses: ruby/setup-ruby@v1
+  #     with:
+  #       ruby-version: ${{ matrix.ruby-version }}
+  #       bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+  #   - name: Rubocop
+  #     run: bundle exec rubocop


### PR DESCRIPTION
Add github action for spec tests (`bundle exec rspec`) and for rubocop ('rubocop'). Rubocop code commented out for now, but will continue to utilize it in PRs and eventually use it as a check in the future. 