### PR TITLE
Restructure Engine

### DIFF
--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -72,18 +72,10 @@ class TestScriptRunnable
 
     autocreate_ids.each do |fixture_id|
       FHIR.logger.info "Auto-creating static fixture #{fixture_id}"
-      execute_operation(action_create(fixture_id))
+      execute_operation(operation_create(fixture_id))
     end
 
     FHIR.logger.info 'Finish pre-processing.'
-  end
-
-  def action_create(sourceId)
-    FHIR::TestScript::Setup::Action::Operation.new({
-      sourceId: sourceId,
-      resource: type,
-      local_method: 'delete'
-    })
   end
 
   def setup_execution
@@ -91,12 +83,36 @@ class TestScriptRunnable
   end
 
   def test_execution
+
   end
 
   def teardown_execution
+
   end
 
   def post_processing
+    FHIR.logger.info 'Begin post-processing.'
+
+    autodelete_ids.each do |fixture_id|
+      FHIR.logger.info "Auto-deleting dynamic fixture #{fixture_id}"
+      execute_operation(operation_delete(fixture_id))
+    end
+
+    FHIR.logger.info 'Finish post-processing.'
+  end
+
+  def operation_create(sourceId)
+    FHIR::TestScript::Setup::Action::Operation.new({
+      sourceId: sourceId,
+      local_method: 'create'
+    })
+  end
+
+  def operation_delete(sourceId)
+    FHIR::TestScript::Setup::Action::Operation.new({
+      targetId: id_map[sourceId],
+      local_method: 'delete'
+    })
   end
 
   def load_fixtures
@@ -134,16 +150,6 @@ class TestScriptRunnable
     rescue StandardError => e
       warn('badReference', ref)
     end
-  end
-
-  def action_delete(sourceId, type)
-    FHIR::TestScript::Setup::Action.new({
-      operation: FHIR::TestScript::Setup::Action::Operation.new({
-        sourceId: sourceId,
-        resource: type,
-        local_method: 'delete'
-      })
-    })
   end
 
   def run client = nil

--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -3,7 +3,6 @@ require 'pry-nav'
 require 'jsonpath'
 require 'fhir_client'
 require_relative 'assertions'
-require_relative './MessageHandler.rb'
 require_relative './TestReportHandler.rb'
 
 class TestScriptRunnable
@@ -50,8 +49,6 @@ class TestScriptRunnable
   end
 
   def initialize script
-    extend MessageHandler
-
     unless (script.is_a? FHIR::TestScript) && script.valid?
       FHIR.logger.error '[.initialize] Received invalid or non-TestScript resource.'
       raise ArgumentError

--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -51,7 +51,7 @@ class TestScriptRunnable
     @script
   end
 
-  def client client = nil
+  def client(client = nil)
     @client = client if client
     @client ||= FHIR::Client.new('https://localhost:8080')
   end
@@ -64,6 +64,16 @@ class TestScriptRunnable
 
     script(script)
     pre_processing
+  end
+
+  def run(client = nil)
+    client(client)
+
+    setup_execution
+    test_execution
+    teardown_execution
+
+    post_processing
   end
 
   def pre_processing
@@ -88,6 +98,7 @@ class TestScriptRunnable
 
   def teardown_execution
 
+    report.finalize
   end
 
   def post_processing
@@ -150,20 +161,6 @@ class TestScriptRunnable
     rescue StandardError => e
       warn('badReference', ref)
     end
-  end
-
-  def run client = nil
-    client client
-
-    [script.setup, *script.test, script.teardown].each do |section|
-      next unless section
-
-      section.action.each do |action|
-        execute_operation(action.operation) || evaluate(action.try(:assert))
-      end
-    end
-
-    report.finalize
   end
 
   def execute_operation(op)

--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -15,7 +15,7 @@ class TestScriptRunnable
                     'history' => :get,
                     nil => :get }.freeze
 
-  attr_accessor :script, :reply
+  attr_accessor :reply
 
   # maps fixture ids to server ids
   def id_map
@@ -39,6 +39,11 @@ class TestScriptRunnable
     @report ||= TestReportHandler.setup(script)
   end
 
+  def script(script = nil)
+    @script = script if script
+    @script
+  end
+
   def client client = nil
     @client = client if client
     @client ||= FHIR::Client.new('https://localhost:8080')
@@ -52,7 +57,7 @@ class TestScriptRunnable
       raise ArgumentError
     end
 
-    self.script = script
+    script(script)
   end
 
   def load_fixtures

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -4,7 +4,7 @@ require './TestScriptRunnable' # TODO: Remove
 
 test_server_url = 'http://server.fire.ly'
 testscript_path = '../TestScripts'
-testscript_file = nil
+testscript_path = nil
 
 parameters = ARGV
 parameters.each do |parameter|

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -4,7 +4,7 @@ require './TestScriptRunnable' # TODO: Remove
 
 test_server_url = 'http://server.fire.ly'
 testscript_path = '../TestScripts'
-testscript_path = nil
+testscript_file = nil
 
 parameters = ARGV
 parameters.each do |parameter|


### PR DESCRIPTION
Restructuring the engine by explicitly adding pre-process, setup, test, teardown, and post-process phases to engine execution. Also added a lot of messages, which will be cleaned up when MessageHandler is improved. 

Note that this is branched from [this PR](https://github.com/fhir-crucible/testscript-engine/pull/19/) but it addresses the issue @jhlee-mitre raised there. I opened as a new PR because the changes included additional restructuring I was planning on doing anyways. But, bottom line is that I will need to merge that in before this one, but will do them immediately after each other to avoid errors in main. 