### PR TITLE
Exclude fixture validation; Quick fix for load_fixtures

### DIFF
--- a/lib/TestScriptEngine.rb
+++ b/lib/TestScriptEngine.rb
@@ -43,6 +43,7 @@ class TestScriptEngine
     FHIR.logger.info "[.load_scripts] TestScript Path: [#{root}]"
 
     on_deck.each do |resource|
+      next if resource.include? "/fixtures/"
       next if file_name && !resource.include?(file_name)
 
       begin 

--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -168,7 +168,7 @@ class TestScriptRunnable
 
   def load_fixtures
     FHIR.logger.info 'Beginning loading fixtures.'
-    script.fixture do |fixture|
+    script.fixture.each do |fixture|
       FHIR.logger.info 'No ID for static fixture, can not process.' unless fixture.id
       FHIR.logger.info 'No resource for static fixture, can not process.' unless fixture.resource
 


### PR DESCRIPTION
In load_scripts method, any files under TestScripts folder (including fixtures) go through TestScript validation. Fixtures are not TestScript and indeed they don't need to be validated. Testers can intentionally put invalid fixtures to test fault tolerance of applications/servers.

In load_fixtures method, each fixture under script needs to go loop -> script.fixture.each