### PR TITLE
Bug Fix - `autodelete_ids` 

### DIFF
--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -42,7 +42,7 @@ class TestScriptRunnable
   end
 
   def autodelete_ids
-    @autocreate_ids ||= []
+    @autodelete_ids ||= []
   end
 
   def script(script = nil)


### PR DESCRIPTION
Realized the `@autocreate_ids` instance variable was being used in the `autodeletes_id` method 🙃