### PR TITLE
Bug Fix: Autocreating Fixtures 

### DIFF
--- a/lib/TestScriptRunnable.rb
+++ b/lib/TestScriptRunnable.rb
@@ -155,14 +155,14 @@ class TestScriptRunnable
   def operation_create(sourceId)
     FHIR::TestScript::Setup::Action::Operation.new({
       sourceId: sourceId,
-      local_method: 'create'
+      method: 'post'
     })
   end
 
   def operation_delete(sourceId)
     FHIR::TestScript::Setup::Action::Operation.new({
       targetId: id_map[sourceId],
-      local_method: 'delete'
+      method: 'delete'
     })
   end
 


### PR DESCRIPTION
The method `operation_create` (and `operation_delete`) tries to assign the `local_method` of the operation element being created. However, this attribute doesn't exist during initialization -- it is initialized through the `method:` keyword, but is accessed in the element instance through `local_method` because `method` already means something in Ruby. 