### PR TITLE
Fix: Remove 'fixture' in reference resolving

### DIFF
--- a/TestScripts/general_testscript.json
+++ b/TestScripts/general_testscript.json
@@ -85,7 +85,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Patient/example.json",
+        "reference": "fixtures/Patient/example.json",
         "display": "Peter Chalmers"
       }
     },
@@ -94,7 +94,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Patient/example.json",
+        "reference": "fixtures/Patient/example.json",
         "display": "Peter Chalmers (minimum)"
       }
     }

--- a/TestScripts/general_testscript_obs.json
+++ b/TestScripts/general_testscript_obs.json
@@ -85,7 +85,7 @@
       "autocreate": true,
       "autodelete": false,
       "resource": {
-        "reference": "Observation/example.json",
+        "reference": "fixtures/Observation/example.json",
         "display": "Glucose [Moles/volume] in Blood"
       }
     }

--- a/TestScripts/history_testscript.json
+++ b/TestScripts/history_testscript.json
@@ -69,7 +69,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Patient/example.json",
+        "reference": "fixtures/Patient/example.json",
         "display": "Peter Chalmers"
       }
     },
@@ -78,7 +78,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Patient/example2.json",
+        "reference": "fixtures/Patient/example2.json",
         "display": "Jaehoon Lee"
       }
     }

--- a/TestScripts/history_testscript_obs.json
+++ b/TestScripts/history_testscript_obs.json
@@ -69,7 +69,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Observation/example.json",
+        "reference": "fixtures/Observation/example.json",
         "display": "Glucose [Moles/volume] in Blood"
       }
     },
@@ -78,7 +78,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Observation/example2.json",
+        "reference": "fixtures/Observation/example2.json",
         "display": "Hemoglobin"
       }
     }

--- a/TestScripts/search_testscript.json
+++ b/TestScripts/search_testscript.json
@@ -67,7 +67,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Patient/example.json",
+        "reference": "fixtures/Patient/example.json",
         "display": "Peter Chalmers"
       }
     }

--- a/TestScripts/search_testscript.xml
+++ b/TestScripts/search_testscript.xml
@@ -570,7 +570,7 @@
     <autodelete value='false'/>
     <autocreate value='false'/>
     <resource>
-      <reference value='Patient/example.json'/>
+      <reference value='fixtures/Patient/example.json'/>
       <display value='Peter Chalmers'/>
     </resource>
   </fixture>

--- a/TestScripts/search_testscript_autocreate.json
+++ b/TestScripts/search_testscript_autocreate.json
@@ -67,7 +67,7 @@
       "autocreate": true,
       "autodelete": true,
       "resource": {
-        "reference": "Patient/example.json",
+        "reference": "fixtures/Patient/example.json",
         "display": "Peter Chalmers"
       }
     }

--- a/TestScripts/search_testscript_obs.json
+++ b/TestScripts/search_testscript_obs.json
@@ -67,7 +67,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Observation/example.json",
+        "reference": "fixtures/Observation/example.json",
         "display": "Glucose [Moles/volume] in Blood"
       }
     }

--- a/TestScripts/update_testscript.json
+++ b/TestScripts/update_testscript.json
@@ -68,7 +68,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Patient/example.json",
+        "reference": "fixtures/Patient/example.json",
         "display": "Peter Chalmers"
       }
     },
@@ -77,7 +77,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Patient/example2.json",
+        "reference": "fixtures/Patient/example2.json",
         "display": "Donald Duck"
       }
     }

--- a/TestScripts/update_testscript_autocreate.json
+++ b/TestScripts/update_testscript_autocreate.json
@@ -68,7 +68,7 @@
       "autocreate": true,
       "autodelete": true,
       "resource": {
-        "reference": "Patient/example.json",
+        "reference": "fixtures/Patient/example.json",
         "display": "Peter Chalmers"
       }
     },
@@ -77,7 +77,7 @@
       "autocreate": true,
       "autodelete": true,
       "resource": {
-        "reference": "Patient/example2.json",
+        "reference": "fixtures/Patient/example2.json",
         "display": "Donald Duck"
       }
     }

--- a/TestScripts/update_testscript_obs.json
+++ b/TestScripts/update_testscript_obs.json
@@ -68,7 +68,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Observation/example.json",
+        "reference": "fixtures/Observation/example.json",
         "display": "Glucose [Moles/volume] in Blood"
       }
     },
@@ -77,7 +77,7 @@
       "autocreate": false,
       "autodelete": false,
       "resource": {
-        "reference": "Observation/example2.json",
+        "reference": "fixtures/Observation/example2.json",
         "display": "Glucose [Moles/volume] in Blood"
       }
     }

--- a/lib/testscript_engine/assertion.rb
+++ b/lib/testscript_engine/assertion.rb
@@ -67,8 +67,8 @@ module Assertion
     if assert.value
       assert.value
     elsif assert.compareToSourceExpression
-      FHIRPath.evaluate(assert.compareToSourceExpression,
-        get_resource(assert.compareToSourceId).to_hash)
+      evaluate_expression(assert.compareToSourceExpression,
+        get_resource(assert.compareToSourceId))
     elsif assert.compareToSourcePath
       evaluate_path(assert.compareToSourcePath,
         get_resource(assert.compareToSourceId))
@@ -135,7 +135,7 @@ module Assertion
     resource = get_resource(assert.sourceId)
     raise AssertionException.new('No resource given by sourceId.', :fail) unless resource
 
-    received = FHIRPath.evaluate(assert.expression, resource.to_hash)
+    received = evaluate_expression(assert.expression, resource)
     expected = determine_expected_value(assert)
     compare("Expression", received, assert.operator, expected)
   end

--- a/lib/testscript_engine/operation.rb
+++ b/lib/testscript_engine/operation.rb
@@ -30,7 +30,7 @@ module Operation
 
     begin
       client.send(*request)
-    rescue
+    rescue => e
       raise OperationException, :bad_request
     end
 

--- a/lib/testscript_engine/testscript_runnable.rb
+++ b/lib/testscript_engine/testscript_runnable.rb
@@ -253,6 +253,10 @@ class TestScriptRunnable
   def evaluate_expression(expression, resource)
     return unless expression and resource
 
-    return FHIRPath.evaluate(expression, resource.to_hash)
+    return begin
+      FHIRPath.evaluate(expression, resource.to_hash)
+    rescue RuntimeError => e
+      return nil
+    end
   end
 end

--- a/lib/testscript_engine/testscript_runnable.rb
+++ b/lib/testscript_engine/testscript_runnable.rb
@@ -185,7 +185,7 @@ class TestScriptRunnable
     end
 
     begin
-      fixture_path = script.url.split('/')[0...-1].join('/') + '/fixtures'
+      fixture_path = script.url.split('/')[0...-1].join('/')
       filepath = File.expand_path(ref, File.absolute_path(fixture_path))
       file = File.open(filepath, 'r:UTF-8', &:read)
       file.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')

--- a/lib/testscript_engine/testscript_runnable.rb
+++ b/lib/testscript_engine/testscript_runnable.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'fhir_models'
 require_relative 'operation'
 require_relative 'assertion'
 require_relative 'message_handler'

--- a/spec/assertions_spec.rb
+++ b/spec/assertions_spec.rb
@@ -17,6 +17,10 @@ class AssertionTestClass
   def reply
     @reply
   end
+
+  def evaluate_expression(input, resource)
+    FHIRPath.evaluate(input, resource.to_hash)
+  end
 end
 
 describe Assertion do

--- a/spec/fixtures/basic_testscript.json
+++ b/spec/fixtures/basic_testscript.json
@@ -9,7 +9,7 @@
       "autocreate": true,
       "autodelete": false,
       "resource": {
-        "reference": "Patient/example.json",
+        "reference": "fixtures/Patient/example.json",
         "display": "Peter Chalmers"
       }
     }

--- a/spec/get_resource_from_ref_spec.rb
+++ b/spec/get_resource_from_ref_spec.rb
@@ -71,10 +71,10 @@ describe TestScriptRunnable do
 
 		it 'given good local reference logs and returns resource' do
 			expect(@runnable).to receive(:info)
-				.with(:loaded_static_fixture, "example_patient.json", "basic_testscript")
+				.with(:loaded_static_fixture, "fixtures/example_patient.json", "basic_testscript")
 
 			@runnable.script.url = "spec/basic_testscript"
-			@reference.reference = "example_patient.json"
+			@reference.reference = "fixtures/example_patient.json"
 			result = @runnable.get_resource_from_ref(@reference)
 
 			expect(result).to be


### PR DESCRIPTION
Removed the implicit addition of 'fixture' to the reference pathway, and manually added the 'fixture' to the beginning of each reference.