### PR TITLE
CLI args for noninteractive and runnable to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ The engine can be configured through several variables, each of which has a pres
 ### Commandline Arguments
 
 Some configurations can be set using command line arguments:
-- `-r` or `--runnable`: the next argument must be the name of runnable to execute. Only works if the noninteractive flag is provided.
+- `-r` or `--runnable`: the next argument must be the name of runnable to execute (from `TestScript.name`). Only works if the noninteractive flag is provided. 
 - `-n` or `--noninteractive`: disable confirmation of configuration settings
+
+For example, to execute the TestScript runnable in file `TestScripts/read_testscript.json` (with name `TestScript Example Read Test`) in non-interactive mode, execute `bundle exec bin/testscript_engine -n -r "TestScript Example Read Test"`.
 
 ## Details
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ The engine can be configured through several variables, each of which has a pres
 - `TESTSCRIPT_PATH`: The relative path to the directory containing the TestScript resources (as JSON or XML) to be executed by the engine. If any TestScript in the directory uses a fixture, the directory MUST also include a `fixtures` subfolder containing files whose relative paths match the reference value of a fixture within a TestScript.
 - `TESTREPORT_PATH`: The relative to the directory containing the TestReports output following their partner TestScript execution.
 
-### Details
+### Commandline Arguments
+
+Some configurations can be set using command line arguments:
+- `-r` or `--runnable`: the next argument must be the name of runnable to execute. Only works if the noninteractive flag is provided.
+- `-n` or `--noninteractive`: disable confirmation of configuration settings
+
+## Details
 
 TestScripts are validated and loaded in by the engine. By default, the engine looks for a `./TestScripts` folder in its given context, but will allow the user to specify an alternate path. Once scripts are loaded, they are converted into 'runnables'. The engine allows users to specify which runnable to execute, and by default will execute all available runnables. Likewise, the user can specify the endpoint upon which the runnable(s) should be executed. Following execution, the user can either re-execute -- specifying a different runnable or endpoint -- or shut-down the engine. Finally, the results from each runnable's latest execution are written out to the `./TestReports` folder.
 
-### Limitations
+## Limitations
 There are known gaps in the TestScript Engine:
 * Support for minimumId
 * Support for validateProfileId
@@ -42,7 +48,7 @@ There are known gaps in the TestScript Engine:
 
 The TestScript Engine is still in the infancy of its development; it is neither fully complete nor bug-free and we encourage contributions, feedback, and issue-opening from the community.
 
-### About the Project
+## About the Project
 
 The purpose of the TestScript Engine is to support and encourage essential aspects of FHIR testing through the following features:
 
@@ -53,7 +59,7 @@ The purpose of the TestScript Engine is to support and encourage essential aspec
 
 
 
-### Folders and Files
+## Folders and Files
   - `./lib`
     - `assertion.rb`
     - `operation.rb`

--- a/lib/testscript_engine/cli.rb
+++ b/lib/testscript_engine/cli.rb
@@ -3,61 +3,94 @@
 class TestScriptEngine
   module CLI
     def self.start
+
       @test_server_url = "http://hapi.fhir.org/baseR4"
       @load_non_fhir_fixtures = true
       @testscript_path = "./TestScripts"
       @testreport_path = "./TestReports"
+      @interactive = true
+      runnable = nil
+
+      i = 0
+      while i < ARGV.length
+        arg = ARGV[i]
+        if (arg == "-n" or arg == "--noninteractive") 
+          @interactive = false
+        elsif (arg == "-r" or arg == "--runnable")
+          runnable = ARGV[i+=1]
+        else
+          raise ArgumentError.new("unexpected command line input at position #{i}: #{arg}")
+        end
+        i += 1
+      end
+
+
 
       Dir.glob("#{Dir.getwd}/**").each do |path|
         @testscript_path = path if path.split('/').last.downcase == 'testscripts'
         @testreport_path = path if path.split('/').last.downcase == 'testreports'
       end
 
-      print "Hello from the TestScriptEngine! "
-      approve_configuration
+      if (@interactive)
+        print "Hello from the TestScriptEngine! "
+        approve_configuration
+      end
 
       engine = TestScriptEngine.new(@test_server_url, @testscript_path, @testreport_path, load_non_fhir_fixtures: @load_non_fhir_fixtures)
       engine.load_input
       engine.make_runnables
 
-      print "Now able to execute runnables. \n"
+      if (@interactive)
+        print "Now able to execute runnables. \n"
+      end
 
       while true
-        puts
-        print "The SERVER UNDER TEST is [#{@test_server_url}]. Would you like to change the SERVER UNDER TEST? [Y/N] "
-        input = gets.chomp
-        if input.strip.downcase == 'y'
+        if (@interactive)
           puts
-          print "Set [SERVER UNDER TEST]: "
-          input = gets.chomp
-          @test_server_url = input unless input.strip == ""
-          engine.new_client(@test_server_url)
-        end
-
-        puts
-
-        print "Enter the ID of a runnable to execute, or press return to execute all runnables: "
-        input = gets.chomp
-        if input.strip == ''
-          input = nil
-        else
-          while !engine.verify_runnable(input)
-            print "	Invalid runnable ID given. Please try again: "
-            input = gets.chomp
+          print "The SERVER UNDER TEST is [#{@test_server_url}]. Would you like to change the SERVER UNDER TEST? [Y/N] "
+          input = STDIN.gets.chomp
+          if input.strip.downcase == 'y'
+            puts
+            print "Set [SERVER UNDER TEST]: "
+            input = STDIN.gets.chomp
+            @test_server_url = input unless input.strip == ""
+            engine.new_client(@test_server_url)
           end
+
+          puts
         end
 
-        engine.execute_runnables(input)
+        
+        if (@interactive)
+          print "Enter the ID of a runnable to execute, or press return to execute all runnables: "
+          runnable = STDIN.gets.chomp
+          if runnable.strip == ''
+            runnable = nil
+          else
+            while !engine.verify_runnable(runnable)
+              print "	Invalid runnable ID given. Please try again: "
+              runnable = STDIN.gets.chomp
+            end
+          end
+        elsif (runnable != nil) && !engine.verify_runnable(runnable)
+          raise ArgumentError.new("invalid runnable provided via command line argument: #{runnable}")
+        end
 
-        puts
-        print "Execution finished. Enter (q) to quit, press any other key to continue execution: "
-        input = gets.chomp
-        break if input == 'q'
+        engine.execute_runnables(runnable)
+
+        if (@interactive)
+          puts
+          print "Execution finished. Enter (q) to quit, press any other key to continue execution: "
+          input = STDIN.gets.chomp
+          break if input == 'q'
+        else 
+          break
+        end
       end
 
       engine.write_reports
 
-      print "Goodbye!"
+      print "Goodbye!" if (@interactive)
     end
 
     def self.configuration
@@ -73,30 +106,30 @@ class TestScriptEngine
       while true
         break if File.file?(path) || File.directory?(path)
         print "	Invalid file or directory path given. Current working directory: [#{Dir.getwd}]. Try again: "
-        path = gets.chomp
+        path = STDIN.gets.chomp
       end
       path
     end
 
     def self.modify_configuration
       print "Set [SERVER UNDER TEST] (press return to skip): "
-      input = gets.chomp
+      input = STDIN.gets.chomp
       @test_server_url = input unless input.strip == ""
 
       print "Set [LOAD NON-FHIR FIXTURES] (expecting T/F, press return to skip): "
-      input = gets.chomp
+      input = STDIN.gets.chomp
       unless input.strip == ""
         @load_non_fhir_fixtures = (input.downcase == 'f' ? false : true )
       end
 
       print "Set [TESTSCRIPT INPUT DIRECTORY or FILE] (press return to skip): "
-      input = gets.chomp
+      input = STDIN.gets.chomp
       unless input.strip == ""
         @testscript_path = validate_path(input.strip)
       end
 
       print "Set [TESTREPORT OUTPUT DIRECTORY] (press return to skip): "
-      input = gets.chomp
+      input = STDIN.gets.chomp
       unless input.strip == ""
         @testreport_path = validate_path(input.strip)
       end
@@ -107,7 +140,7 @@ class TestScriptEngine
     def self.approve_configuration
       while true
         print configuration
-        input = gets.chomp
+        input = STDIN.gets.chomp
         puts
         if input.strip.downcase == 'y'
           modify_configuration


### PR DESCRIPTION
# Summary

Add option for command line arguments to the CLI, initially including
- disable interactivity
- specify the runnable to execute

## New behavior
CLI supports arguments
- -n or --noninteractive to disable user input
- -r or --runnable to specify the runnable name, works only if noninteractive mode usedd

## Code changes

updates to the CLI module to support using inputs from ARGV

## Testing guidance

run `bundle exec bin/testscript_engine` with additional arguments
