### PR TITLE
Dynamic variable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'http://rubygems.org'
 
 gemspec
 gem 'thor'
+gem 'ffi'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.0)
+    ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
     fhir_client (5.0.3)
       activesupport (>= 3)
       addressable (>= 2.3)
@@ -73,6 +75,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     netrc (0.11.0)
+    nokogiri (1.13.8-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -118,17 +122,20 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
+    unf_ext (0.0.8.2-x64-mingw-ucrt)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
+  ffi
   pry-nav (~> 1.0.0)
   rspec (~> 3.10)
   testscript_engine!

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Below are properties in the configuration files.
 - `testscript_name : [TESTSCRIPT.NAME]` Name of TestScript to be executed. If empty, all files under testscript_path will be executed.
 - `testscript_path : [PATH]` The relative path to the directory containing the TestScript resources (as JSON or XML) to be executed by the engine.
 - `testreport_path : [PATH]` The relative to the directory containing the TestReports output following their partner TestScript execution.
+- `variable : [- name1=value1 - name2=value2 ..]`: Replace defaultValue in variable by user defined value. This will apply to all runnables uniformly as long as names match. No space before and after =. Multiple variables are distinguished by line.
 - `server_url : [URL]` Endpoint against which TestScripts will be executed.
 - `nonfhir_fixture : [TRUE/FALSE]` Whether to allow intake non-FHIR fixtures.
 - `ext_validator : [URL]` If specified, use external resource validator instead of internal validator.
@@ -55,6 +56,7 @@ Command line arguments can be used when you want to run specific files and/or co
 - `--testscript_path [PATH]`: Folder location of TestScripts (default: /TestScripts)
 - `--testreport_path [PATH]`: Folder location of TestReports (default: /TestReports)
 - `--server_url [URL]`: If specified, it will replace the default FHIR server in the configuration file.
+- `--variable [name1=value1 name2=value2 ..]`: Replace defaultValue in variable by user defined value. This will apply to all runnables uniformly as long as names match. No space before and after =. Use quotations if value has space.
 - `--nonfhir_fixture [TRUE/FALSE]`: Whether allow to intake non-FHIR fixture or not.
 - `--ext_validator [URL]`: If specified, use external resource validator.
 - `--ext_fhirpath [URL]`: If specified, use external FHIR path evaluator.

--- a/TestScripts/general_testscript.json
+++ b/TestScripts/general_testscript.json
@@ -11,7 +11,8 @@
     "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.9876"
   },
   "version": "1.0",
-  "name": "TestScript Example General",
+  "name": "testscript-example-general",
+  "title": "TestScript Example General",
   "status": "draft",
   "experimental": true,
   "date": "2017-01-18",

--- a/TestScripts/history_testscript.json
+++ b/TestScripts/history_testscript.json
@@ -11,7 +11,8 @@
     "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.9877"
   },
   "version": "1.0",
-  "name": "TestScript Example History",
+  "name": "testscript-example-history",
+  "title": "TestScript Example History",
   "status": "draft",
   "experimental": true,
   "date": "2017-01-18",

--- a/TestScripts/read_testscript.json
+++ b/TestScripts/read_testscript.json
@@ -11,7 +11,8 @@
     "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.9879"
   },
   "version": "1.0",
-  "name": "TestScript Example Read Test",
+  "name": "testscript-example-readtest",
+  "title": "TestScript Example Read Test",
   "status": "draft",
   "experimental": true,
   "date": "2017-01-18",

--- a/TestScripts/search_testscript.json
+++ b/TestScripts/search_testscript.json
@@ -11,7 +11,8 @@
     "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.9881"
   },
   "version": "1.0",
-  "name": "TestScript Example Search",
+  "name": "testscript-example-search",
+  "title": "TestScript Example Search",
   "status": "draft",
   "experimental": true,
   "date": "2017-01-18",

--- a/TestScripts/update_testscript.json
+++ b/TestScripts/update_testscript.json
@@ -11,7 +11,8 @@
     "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.9882"
   },
   "version": "1.0",
-  "name": "TestScript Example Update",
+  "name": "testscript-example-update",
+  "title": "TestScript Example Update",
   "status": "draft",
   "experimental": true,
   "date": "2017-01-18",

--- a/config.yml
+++ b/config.yml
@@ -5,14 +5,21 @@ nonfhir_fixture: true
 server_url: http://server.fire.ly
 
 # The relative path to the directory containing the TestScript resources (as JSON or XML) to be executed by the engine
-testscript_path: "./TestScripts"
+testscript_path: "/spec/examples/testscript_unittest"
  
 # Name of TestScript under TESTSCRIPT_PATH to be executed
 # If empty, all files under TESTSCRIPT_PATH will be executed
-testscript_name:
-# Example:
+testscript_name: testscript_dynamic_variable
+# Example: 
 # testscript_name: TestScript Example General
 # Handling multiple TestScript names will be added
+
+# Dynamic variables will replace defaultValue in variable in TestScript
+# Dynamic variables uniformly apply to all runnables. For example, if two TestScripts have same variable names, dynamic variable will apply to both of them.
+# Example: PatientResourceId1=var1changed
+variable:
+- PatientResourceId1 = var1changed
+- PatientResourceId2 = var2changed
 
 # The relative to the directory containing the TestReports output following their partner TestScript execution
 testreport_path: "./TestReports"
@@ -23,7 +30,7 @@ testreport_path: "./TestReports"
 #   https://github.com/fhir-crucible/fhir_models
 # - "external" uses the a web interface for the L7 FHIR validator.
 #   https://github.com/inferno-community/fhir-validator-wrapper
-ext_validator: http://resource_validator_service:1234
+ext_validator: 
 
 # If specified, the url where the external fhirpath will be used. If not use the internal fhirpath.
-ext_fhirpath: http://fhirpath_validator_service:1234
+ext_fhirpath: 

--- a/lib/testscript_engine.rb
+++ b/lib/testscript_engine.rb
@@ -113,7 +113,7 @@ class TestScriptEngine
   def dynamic_variable(script)
     script.variable.each do |v|
       variable.each do |v2|
-        v.defaultValue = v2.gsub(" =","=").gsub("= ","=").split("=").last if v2.gsub(" =","=").gsub("= ","=").split("=").first == v.name && v.defaultValue != nil
+        v.defaultValue = v2.split("=").last if v2.split("=").first == v.name && v.defaultValue != nil
       end
     end
     return script

--- a/lib/testscript_engine.rb
+++ b/lib/testscript_engine.rb
@@ -11,7 +11,7 @@ class TestScriptEngine
   prepend MessageHandler
   include Validation
 
-  attr_accessor :endpoint, :input_path, :testreport_path, :nonfhir_fixture, :resource_validator, :fhirpath_evaluator
+  attr_accessor :endpoint, :input_path, :testreport_path, :nonfhir_fixture, :resource_validator, :fhirpath_evaluator, :variable
 
   def fixtures
     @fixtures ||= {}
@@ -45,6 +45,7 @@ class TestScriptEngine
     self.nonfhir_fixture = options[:nonfhir_fixture]
     self.resource_validator = options[:resource_validator]
     self.fhirpath_evaluator = options[:fhirpath_evaluator]
+    self.variable = options["variable"]
     # self.debug_mode = true
   end
 
@@ -93,17 +94,29 @@ class TestScriptEngine
   #                            transformed into and stored as runnables.
   def make_runnables(script = nil)
     get_fixtures = ->(fixture_name) { fixtures[fixture_name] }
+    
     if valid_testscript? script
       info(:creating_runnable, script.name)
+      script = dynamic_variable(script) if script.variable && variable
       runnables[script.name] = TestScriptRunnable.new(script, get_fixtures)
     else
       scripts.each do |_name, script|
         info(:creating_runnable, script.name)
+        script = dynamic_variable(script) if script.variable && variable
         runnables[script.name] = TestScriptRunnable.new(script, get_fixtures)
       end
     end
   rescue StandardError
     error(:unable_to_create_runnable, script.name)
+  end
+
+  def dynamic_variable(script)
+    script.variable.each do |v|
+      variable.each do |v2|
+        v.defaultValue = v2.gsub(" =","=").gsub("= ","=").split("=").last if v2.gsub(" =","=").gsub("= ","=").split("=").first == v.name && v.defaultValue != nil
+      end
+    end
+    return script
   end
 
   # TODO: Clean-up, possibly modularize into a pretty_print type method

--- a/lib/testscript_engine/cli.rb
+++ b/lib/testscript_engine/cli.rb
@@ -14,7 +14,7 @@ class TestScriptEngine
         puts "  execute --nonfhir_fixture [true/false]: allow to intake non-FHIR fixture"
         puts "  execute --ext_validator [URL]: when specified, use external resource validator"
         puts "  execute --ext_fhirpath [URL]: when specified, use external FHIR path evaluator"
-        puts "  execute --variable ['name1=value1' 'name2=value2'...]: when specified, replace the default FHIR server"
+        puts "  execute --variable ['name1=value1' 'name2=value2'...]: when specified, replace defaultValue in variable"
         puts "  execute --server_url [URL]: when specified, replace the default FHIR server"
         puts "  execute --testscript_path [FILEPATH]: TestScript location (default: /TestScripts)"
         puts "  execute --testreport_path [FILEPATH]: TestReport location (default: /TestReports)"

--- a/lib/testscript_engine/cli.rb
+++ b/lib/testscript_engine/cli.rb
@@ -14,17 +14,19 @@ class TestScriptEngine
         puts "  execute --nonfhir_fixture [true/false]: allow to intake non-FHIR fixture"
         puts "  execute --ext_validator [URL]: when specified, use external resource validator"
         puts "  execute --ext_fhirpath [URL]: when specified, use external FHIR path evaluator"
+        puts "  execute --variable ['name1=value1' 'name2=value2'...]: when specified, replace the default FHIR server"
         puts "  execute --server_url [URL]: when specified, replace the default FHIR server"
         puts "  execute --testscript_path [FILEPATH]: TestScript location (default: /TestScripts)"
         puts "  execute --testreport_path [FILEPATH]: TestReport location (default: /TestReports)"
       end
 
-      desc "execute [OPTIONS]", "--nonfhir_fixture --ext_validator [URL] --ext_fhirpath [URL] --server_url [URL] --testscript_path [FILEPATH] --testreport_path [FILEPATH]"
+      desc "execute [OPTIONS]", "--nonfhir_fixture --ext_validator [URL] --ext_fhirpath [URL] --variable ['name = value'] --server_url [URL] --testscript_path [FILEPATH] --testreport_path [FILEPATH]"
       option :config
       option :nonfhir_fixture
       option :ext_validator
       option :ext_fhirpath
       option :server_url
+      option :variable, :type => :array
       option :testscript_path
       option :testscript_name
       #We will change later to accommodate multiple testscript names
@@ -48,9 +50,9 @@ class TestScriptEngine
     def self.start
   
       @test_server_url = "http://server.fire.ly"
-      @testscript_path = "./TestScripts"
+      @testscript_path = "/TestScripts"
       @testscript_name = nil
-      @testreport_path = "./TestReports"
+      @testreport_path = "/TestReports"
       @load_non_fhir_fixtures = true
       @ext_validator = nil
       @ext_fhirpath = nil
@@ -77,16 +79,19 @@ class TestScriptEngine
       else
         options = {}
       end
-
+      
       @test_server_url = options["server_url"] if options["server_url"]
       @testscript_path = options["testscript_path"] if options["testscript_path"]
       @testreport_path = options["testreport_path"] if options["testreport_path"]
       @load_non_fhir_fixtures = options["nonfhir_fixture"] if options["nonfhir_fixture"]
       runnable = options["testscript_name"] if options["testscript_name"]
+      
+      @testscript_path = Dir.getwd + @testscript_path
+      @testreport_path = Dir.getwd + @testreport_path
 
       Dir.glob("#{Dir.getwd}/**").each do |path|
-        @testscript_path = path if path.split('/').last.downcase == 'testscripts'
-        @testreport_path = path if path.split('/').last.downcase == 'testreports'
+        #@testscript_path = path if path.split('/').last.downcase == 'testscripts'
+        #@testreport_path = path if path.split('/').last.downcase == 'testreports'
       end
 
       if (@interactive)

--- a/lib/testscript_engine/validation/validation.rb
+++ b/lib/testscript_engine/validation/validation.rb
@@ -33,7 +33,8 @@ module Validation
   # endpoint, and return whether the response conveys validation errors
   def valid_resource?(resource, *profiles)
     initial_logger = FHIR.logger
-    FHIR.logger = Logger.new('/dev/null')
+    #FHIR.logger = Logger.new('/dev/null')
+    FHIR.logger = Logger.new(STDOUT)
     validate_using_operation(resource, profiles)
     validate_using_route(resource, profiles) unless reply.response[:code].start_with?('2')
     FHIR.logger = initial_logger

--- a/spec/engine/testscript_engine_spec.rb
+++ b/spec/engine/testscript_engine_spec.rb
@@ -19,7 +19,7 @@ describe TestScriptEngine do
       @engine.load_input
 
       expect(@engine.fixtures.keys.length).to be(1)
-      expect(@engine.scripts.keys.length).to be(14)
+      expect(@engine.scripts.keys.length).to be(15)
     end
 
     it 'loads file if given file path' do

--- a/spec/examples/testscript_unittest/testscript_dynamic_variable.json
+++ b/spec/examples/testscript_unittest/testscript_dynamic_variable.json
@@ -1,0 +1,133 @@
+{
+  "resourceType": "TestScript",
+  "id": "testscript-example-readtest",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: testscript-example-readtest</p><p><b>url</b>: <b>http://hl7.org/fhir/TestScript/testscript-example-readtest</b></p><p><b>identifier</b>: urn:oid:1.3.6.1.4.1.21367.2005.3.7.9879</p><p><b>version</b>: 1.0</p><p><b>name</b>: TestScript Example Read Test</p><p><b>status</b>: draft</p><p><b>experimental</b>: true</p><p><b>date</b>: 18/01/2017</p><p><b>publisher</b>: HL7</p><p><b>contact</b>: </p><p><b>description</b>: TestScript example resource with ported Sprinkler basic read tests R001, R002, R003, R004. The read tests will utilize user defined dynamic variables that will hold the Patient resource id values.</p><p><b>jurisdiction</b>: United States of America (the) <span>(Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United States of America (the)'})</span></p><p><b>purpose</b>: Patient Read Operation</p><p><b>copyright</b>: © HL7.org 2011+</p><blockquote><p><b>metadata</b></p><h3>Links</h3><table><tr><td>-</td><td><b>Url</b></td><td><b>Description</b></td></tr><tr><td>*</td><td><a>http://hl7.org/fhir/patient.html</a></td><td>Demographics and other administrative information about an individual or animal receiving care or other health-related services.</td></tr></table><h3>Capabilities</h3><table><tr><td>-</td><td><b>Required</b></td><td><b>Validated</b></td><td><b>Description</b></td><td><b>Link</b></td><td><b>Capabilities</b></td></tr><tr><td>*</td><td>true</td><td>false</td><td>Patient Read Operation</td><td><a>http://hl7.org/fhir/http.html#read</a></td><td><a>CapabilityStatement/example</a></td></tr></table></blockquote><p><b>profile</b>: <a>Generated Summary: url: http://hl7.org/fhir/StructureDefinition/Patient; version: 4.0.1; name: Patient; ACTIVE; date: 01/11/2019 9:29:23 AM; publisher: Health Level Seven International (Patient Administration); description: Demographics and other administrative information about an individual or animal receiving care or other health-related services.; purpose: Tracking patient is the center of the healthcare process.; 4.0.1; RESOURCE; type: Patient; baseDefinition: http://hl7.org/fhir/StructureDefinition/DomainResource; SPECIALIZATION</a></p><blockquote><p><b>variable</b></p><p><b>name</b>: KnownPatientResourceId</p><p><b>defaultValue</b>: example</p></blockquote><blockquote><p><b>variable</b></p><p><b>name</b>: NonExistsPatientResourceId</p><p><b>defaultValue</b>: does-not-exist</p></blockquote><blockquote><p><b>test</b></p><p><b>name</b>: Sprinkler Read Test R001</p><p><b>description</b>: Read a known Patient and validate response.</p><blockquote><p><b>action</b></p><h3>Operations</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote><blockquote><p><b>action</b></p><h3>Asserts</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote><blockquote><p><b>action</b></p><h3>Asserts</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote><blockquote><p><b>action</b></p><h3>Asserts</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote><blockquote><p><b>action</b></p><h3>Asserts</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote><blockquote><p><b>action</b></p><h3>Asserts</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote></blockquote><blockquote><p><b>test</b></p><p><b>name</b>: Sprinkler Read Test R002</p><p><b>description</b>: Read an unknown Resource Type and validate response.</p><blockquote><p><b>action</b></p><h3>Operations</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote><blockquote><p><b>action</b></p><h3>Asserts</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote></blockquote><blockquote><p><b>test</b></p><p><b>name</b>: Sprinkler Read Test R003</p><p><b>description</b>: Read a known, non-existing Patient and validate response.</p><blockquote><p><b>action</b></p><h3>Operations</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote><blockquote><p><b>action</b></p><h3>Asserts</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote></blockquote><blockquote><p><b>test</b></p><p><b>name</b>: Sprinkler Read Test R004</p><p><b>description</b>: Read a Patient using a known bad formatted resource id and validate response.</p><blockquote><p><b>action</b></p><h3>Operations</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote><blockquote><p><b>action</b></p><h3>Asserts</h3><table><tr><td>-</td></tr><tr><td>*</td></tr></table></blockquote></blockquote></div>"
+  },
+  "url": "http://hl7.org/fhir/TestScript/testscript-example-readtest",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:1.3.6.1.4.1.21367.2005.3.7.9879"
+  },
+  "version": "1.0",
+  "name": "testscript_dynamic_variable",
+  "status": "draft",
+  "experimental": true,
+  "date": "2017-01-18",
+  "publisher": "HL7",
+  "contact": [
+    {
+      "name": "Support",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "support@HL7.org",
+          "use": "work"
+        }
+      ]
+    }
+  ],
+  "description": "TestScript example resource with ported Sprinkler basic read tests R001, R002, R003, R004. The read tests will utilize user defined dynamic variables that will hold the Patient resource id values.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US",
+          "display": "United States of America (the)"
+        }
+      ]
+    }
+  ],
+  "purpose": "Patient Read Operation",
+  "copyright": "© HL7.org 2011+",
+  "metadata": {
+    "link": [
+      {
+        "url": "http://hl7.org/fhir/patient.html",
+        "description": "Demographics and other administrative information about an individual or animal receiving care or other health-related services."
+      }
+    ],
+    "capability": [
+      {
+        "required": true,
+        "validated": false,
+        "description": "Patient Read Operation",
+        "link": [
+          "http://hl7.org/fhir/http.html#read"
+        ],
+        "capabilities": "http://hl7.org/fhir/CapabilityStatement/example"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "name": "PatientResourceId1",
+      "defaultValue": "default"
+    },
+    {
+      "name": "PatientResourceId2",
+      "defaultValue": "default"
+    },
+    {
+      "name": "PatientResourceId3"
+    }
+  ],
+  "test": [
+    {
+      "id": "R001",
+      "name": "Sprinkler Read Test R001",
+      "description": "Read a known Patient and validate response.",
+      "action": [
+        {
+          "operation": {
+            "type": {
+              "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+              "code": "read"
+            },
+            "resource": "Patient",
+            "description": "Read the known Patient resource on the destination test system using the user defined dynamic variable ${KnownPatientResourceId}.",
+            "accept": "xml",
+            "encodeRequestUrl": true,
+            "params": "/${PatientResourceId1}"
+          }
+        },
+        {
+          "assert": {
+            "description": "Confirm that the returned HTTP status is 200(OK).",
+            "response": "okay",
+            "warningOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "id": "R002",
+      "name": "Sprinkler Read Test R002",
+      "description": "Read a known Patient and validate response.",
+      "action": [
+        {
+          "operation": {
+            "type": {
+              "system": "http://terminology.hl7.org/CodeSystem/testscript-operation-codes",
+              "code": "read"
+            },
+            "resource": "Patient",
+            "description": "Read the known Patient resource on the destination test system using the user defined dynamic variable ${KnownPatientResourceId}.",
+            "accept": "xml",
+            "encodeRequestUrl": true,
+            "params": "/${PatientResourceId2}"
+          }
+        },
+        {
+          "assert": {
+            "description": "Confirm that the returned HTTP status is 200(OK).",
+            "response": "okay",
+            "warningOnly": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,8 @@ WebMock.enable!
 
 RSpec.configure do |config|
   config.before(:all) do
-    FHIR.logger = Logger.new('/dev/null')
+    #FHIR.logger = Logger.new('/dev/null')
+    FHIR.logger = Logger.new(STDOUT)
     $stdout = File.open(File::NULL, "w")
   end
 end


### PR DESCRIPTION
# Summary
Dynamic variable

## New behavior
Users can set up dynamic variable as a placeholder for user-defined execution time values for [TestScript.variable](https://www.hl7.org/fhir/testscript-definitions.html#TestScript.variable). Technically dynamic variable will replace value in [defaultValue](https://www.hl7.org/fhir/testscript-definitions.html#TestScript.variable.defaultValue) at the beginning of test execution. 
There are two ways to set up dynamic variable:

### Config.yml
variable : [ARRAY] 

Use format 
```
- name1=value1
- name2=value2
```

### Command line argument
bundle exec testscript_engine execution --variable [ARRAY] 

Use format 
`name1=value1 name2=value2`

Use quotations if there are spaces.

## Testing guidance
Sample TestScript `testscript_dynamic_variable` is included. 
Use the examples below from command line argument.

`bundle exec testscript_engine execute --testscript_path "/spec/examples/testscript_unittest" --variable PatientResourceId1=var1changed PatientResourceId2=var2changed --testscript_name testscript_dynamic_variable`

### Expected result

```
STARTING TO TEST
         GETTING: http://server.fire.ly/Patient/var1changed
         (✓) Executed Operation: [unlabeled]
         (✗) Response: Expected Response equals ["okay"], but found [].
         GETTING: http://server.fire.ly/Patient/var2changed
         (✓) Executed Operation: [unlabeled]
         (✗) Response: Expected Response equals ["okay"], but found [].
      FINISHED TEST.
