### PR TITLE
Validate profile id feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Running the engine on a configuration file provides testing on predefined settin
 Below are properties in the configuration files.
 - `testscript_name : [TESTSCRIPT.NAME]` Name of TestScript to be executed. If empty, all files under testscript_path will be executed.
 - `testscript_path : [PATH]` The relative path to the directory containing the TestScript resources (as JSON or XML) to be executed by the engine.
-- `testreport_path : [PATH]` The relative to the directory containing the TestReports output following their partner TestScript execution.
+- `testreport_path : [PATH]` The relative to the directory containing the TestReports output following their partner TestScript execution. Files containing TestReport instances will be placed in a subfolder corresponding to the execution completion time.
 - `summary_path : [PATH]` If specified, a summary report csv file named execution_summary_[UTC timestamp].csv will be created within the specified relative folder. The file will include the id, name, and title of each TestScript executed and the overall pass/fail result. For systems without robust TestReport capabilities, provides an easy way to view the results of a test run across multiple scripts.
 - `variable : [- name1=value1 - name2=value2 ..]`: Replace defaultValue in variable by user defined value. This will apply to all runnables uniformly as long as names match. No space before and after =. Multiple variables are distinguished by line.
 - `profile : [- location1 - location2 ..]`: List of locations holding profile StructureDefinitions to be used for profile validation. May be a web url, a relative file, or a relative directory (profiles in sub-directories not included). StructureDefinitions loaded from this configuration setting take precedence over StructureDefinitions accessed from canonical URLs in TestScripts that resolve to StructureDefinitions. This allows for validation against unpublished versions of profiles.
@@ -56,7 +56,7 @@ Command line arguments can be used when you want to run specific files and/or co
 - `--config [FILENAME]`: Name of configuration file.
 - `--testscript_name [TESTSCRIPT.NAME]`: Name of TestScript to be execute. If not specified, all files under testscript_path will be executed.
 - `--testscript_path [PATH]`: Folder location of TestScripts (default: /TestScripts)
-- `--testreport_path [PATH]`: Folder location of TestReports (default: /TestReports)
+- `--testreport_path [PATH]`: Folder location of TestReports (default: /TestReports). Files containing TestReport instances will be placed in a subfolder corresponding to the execution completion time.
 - `--summary_path [PATH]` If specified, a summary report csv file named execution_summary_[UTC timestamp].csv will be created within the specified relative folder. The file will include the id, name, and title of each TestScript executed and the overall pass/fail result. For systems without robust TestReport capabilities, provides an easy way to view the results of a test run across multiple scripts.
 - `--server_url [URL]`: If specified, it will replace the default FHIR server in the configuration file.
 - `--variable [name1=value1 name2=value2 ..]`: Replace defaultValue in variable by user defined value. This will apply to all runnables uniformly as long as names match. No space before and after =. Use quotations if value has space.
@@ -73,7 +73,7 @@ Running the engine on interactive mode provides flexibility to change the proper
 
 ## Folders and Files
 
-TestScripts are validated and loaded in by the engine. By default, the engine looks for a `./TestScripts` folder in its given context, but will allow the user to specify an alternate path. Once scripts are loaded, they are converted into 'runnables'. The engine allows users to specify which runnable to execute, and by default will execute all available runnables. Likewise, the user can specify the endpoint upon which the runnable(s) should be executed. Following execution, the user can either re-execute -- specifying a different runnable or endpoint -- or shut-down the engine. Finally, the results from each runnable's latest execution are written out to the `./TestReports` folder.
+TestScripts are validated and loaded in by the engine. By default, the engine looks for a `./TestScripts` folder in its given context, but will allow the user to specify an alternate path. Once scripts are loaded, they are converted into 'runnables'. The engine allows users to specify which runnable to execute, and by default will execute all available runnables. Likewise, the user can specify the endpoint upon which the runnable(s) should be executed. Following execution, the user can either re-execute -- specifying a different runnable or endpoint -- or shut-down the engine. Finally, the results from each runnable's latest execution are written out to a subfolder corresponding to the execution completion time under the `./TestReports` folder. 
 
   - `./lib`
     - `assertion.rb`
@@ -108,7 +108,7 @@ TestScripts are validated and loaded in by the engine. By default, the engine lo
   - Folder containing all existing unit tests for both TestScriptEngine and TestScriptRunnable
 
 `./TestReports`:
-  - Folder containing the TestReport(s) created while executing (a) given TestScript(s).
+  - Folder containing the TestReport(s) created while executing (a) given TestScript(s). Files containing TestReport instances will be placed in a subfolder corresponding to the execution completion time
 
 `./TestScripts`:
   - Folder that contains the TestScripts to be executed. Any example resources used within those TestScripts (i.e. using a patient resource as a fixture) should be located within the `./fixtures` subfolder.
@@ -117,12 +117,11 @@ TestScripts are validated and loaded in by the engine. By default, the engine lo
 ### Assertion
 The engine uses various algorithms to evaluate the results of previous operations to determine if the server under test behaves appropriately.
 * minimum_id: Per the [TestScript specification](http://www.hl7.org/fhir/testscript-definitions.html#TestScript.setup.action.assert.minimumId), an assertion with the minimumId element populated asserts that the target instance (current response or instance pointed to by sourceId) "contains all the element/content" from the minimumId instance (the instance pointed to by the minimumId element). For the implementation within this engine, an assertion with minimumId specified passes if and only if each element and list entry within the minimumId instance can be found within the target instance at the same levels within the heirarchy. With respect to lists, entries are not required to appear at the same index or in the same order. Instead, for each entry within the minimumId instance the engine must find a unique corresponding list entry within the target instance that contains all of the elements and content in the minimumId instance's entry. Note that the engine takes a greedy approach to identifying list entries that match, which means there exist pathological cases for which the implementation fails to find matches when they do in fact exist.
+* validateProfileId: Details rely on the validator used. Currently, the engine uses the [FHIR Crucible](https://github.com/fhir-crucible/fhir_models) FHIR validator logic by default. The engine can also be configured to use an external validator based on the [Inferno FHIR validator wrapper](https://github.com/inferno-community/fhir-validator-wrapper). 
 
 ## Limitations
 The TestScript Engine is still in the infancy of its development; it is neither fully complete nor bug-free and we encourage contributions, feedback, and issue-opening from the community. There are known gaps in the TestScript Engine:
 
-* Support for validateProfileId
-* Support for use of an external validator
 * Support for multiple origins and/or destinations
 
 ## References

--- a/config-multipleMCODE.yml
+++ b/config-multipleMCODE.yml
@@ -43,9 +43,12 @@ variable:
   - targetResourceIdTumorSize=tumor-size-jenny-m
 
 # The relative to the directory containing the TestReports output following their partner TestScript execution
-testreport_path: "./TestReports"
+# Files containing TestReport instances will be placed in a subfolder corresponding to the execution completion time
+testreport_path: "TestReports"
 
-summary_path: "./Summaries"
+# If specified, a summary report csv file named execution_summary_[timestamp].csv will be created within the specified relative folder
+# The file will include the id, name, and title of each TestScript executed along with the overall pass/fail result and the file containing the TestReport with details
+summary_path: "TestReports"
 
 # Whether use FHIR logger
 verbose: false
@@ -54,9 +57,9 @@ verbose: false
 # Resource validator options:
 # - "internal" uses the ruby validator from the fhir_models gem
 #   https://github.com/fhir-crucible/fhir_models
-# - "external" uses the a web interface for the L7 FHIR validator.
+# - "external" uses the a web interface for the HL7 FHIR validator.
 #   https://github.com/inferno-community/fhir-validator-wrapper
-ext_validator: https://inferno.healthit.gov/validatorapi
+ext_validator: http://inferno.healthit.gov/validatorapi
 
 # If specified, the url where the external fhirpath will be used. If not use the internal fhirpath.
 ext_fhirpath: 

--- a/config.yml
+++ b/config.yml
@@ -24,11 +24,12 @@ variable:
 - name2=value2
 
 # The relative to the directory containing the TestReports output following their partner TestScript execution
-testreport_path: "./TestReports"
+# Files containing TestReport instances will be placed in a subfolder corresponding to the execution completion time
+testreport_path: "TestReports"
 
-# If specified, a summary report csv file named execution_summary_[UTC timestamp].csv will be created within the specified relative folder
-# The file will include the id, name, and title of each TestScript executed and the overall pass/fail result
-summary_path: "./Summaries"
+# If specified, a summary report csv file named execution_summary_[timestamp].csv will be created within the specified relative folder
+# The file will include the id, name, and title of each TestScript executed along with the overall pass/fail result and the file containing the TestReport with details
+summary_path: "TestReports"
 
 # If specified, use the external validator with URL
 # If not, use the internal validator based on Ruby Crucible validator: https://github.com/fhir-crucible/fhir_models#validation

--- a/lib/testscript_engine.rb
+++ b/lib/testscript_engine.rb
@@ -239,25 +239,26 @@ class TestScriptEngine
   # @path [String] Optional, specifies the path to the folder which the
   #                TestReport resources should be written to.
   def write_reports(path = nil)
+    report_time = DateTime.now.to_s
     report_directory = path || testreport_path
-    FileUtils.mkdir_p report_directory
+    execution_directory = File.join(report_directory, report_time)
+    FileUtils.mkdir_p execution_directory
 
-    summary_rows = [["id", "name", "title", "result"]]
+    summary_rows = [["id", "name", "title", "result", "TestReport file"]]
 
     reports.each do |report_key, report|
-      report_name = report.name.downcase.split(' ')[1...].join('_')
-      report_name = report.name.downcase.split('_')[0...].join('_') if report_name == ''
-      File.open("#{report_directory}/#{report_name}.json", 'w') do |f|
+      report_filename = "#{execution_directory}/#{report.id}.json"
+      File.open(report_filename, 'w') do |f|
         f.write(report.to_json)
       end
       test_script = runnables[report_key]
-      summary_rows << [test_script.script.id, test_script.script.name, """#{test_script.script.title}""", report.result]
+      summary_rows << [test_script.script.id, test_script.script.name, """#{test_script.script.title}""", report.result, report_filename]
     end
 
     if options["summary_path"] != nil
       summary_path = File.join(Dir.getwd, options["summary_path"])
       FileUtils.mkdir_p summary_path
-      File.write(File.join(summary_path, "execution_summary_#{Time.now.utc.iso8601}.csv"), summary_rows.map(&:to_csv).join)
+      File.write(File.join(summary_path, "execution_summary_#{report_time}.csv"), summary_rows.map(&:to_csv).join)
     end
 
 

--- a/lib/testscript_engine/assertion.rb
+++ b/lib/testscript_engine/assertion.rb
@@ -166,12 +166,15 @@ module Assertion
 
     if ext_validator_url == nil #Run internal validator
       print_out " validateProfileId: trying the Ruby Crucible validator"
-      outcome = profile.validates_resource?(get_resource(sourceId))
+      validation_issues = profile.validate_resource(get_resource(sourceId))
+      passed = validation_issues.empty?
+      
 
-      if outcome
-        return " As expected, fixture '#{sourceId}' conforms to profile: '#{validateProfileId}'"
+      if validation_issues.empty?
+        return "#{sourceId ? "Fixture '#{sourceId}'" : "The last response"} conforms to profile '#{validateProfileId}'."
       else
-        fail_message = " Failed, fixture '#{sourceId}' doesn't conform to profile: '#{validateProfileId}'"
+        message = validation_issues.reduce("") { |ag_text, one_issue| "#{ag_text}#{";" unless ag_text == ""} #{one_issue}" }
+        fail_message = "#{sourceId ? "Fixture '#{sourceId}'" : "The last response"} does not conform to profile '#{validateProfileId}'.#{message ? " Details -#{message}" : ""}"
         raise AssertionException.new(fail_message, :fail)
       end
 

--- a/lib/testscript_engine/testreport_handler.rb
+++ b/lib/testscript_engine/testreport_handler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'securerandom'
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #                                                                               #
@@ -167,8 +168,8 @@ module TestReportHandler
       report.result = 'pending'
       report.status = 'in-progress'
       report.tester = 'The MITRE Corporation'
-      report.id = testscript_blueprint.id&.gsub(/(?i)testscript/, 'testreport')
-      report.name = testscript_blueprint.name&.gsub(/(?i)testscript/, 'testreport')
+      report.id = SecureRandom.uuid
+      report.name = "TestReport for " + testscript_blueprint.name
       report.testScript = FHIR::Reference.new({
         reference: testscript_blueprint.url,
         type: "http://hl7.org/fhir/R4B/testscript.html"

--- a/spec/examples/testreport_outline.json
+++ b/spec/examples/testreport_outline.json
@@ -1,6 +1,6 @@
 {
-  "id": "basic_testreport",
-  "name": "basic_testreport",
+  "id": "[UUID]",
+  "name": "TestReport for basic_testscript",
   "status": "in-progress",
   "testScript": {
     "reference": "spec/examples/basic_testscript",

--- a/spec/testreport_handler_spec.rb
+++ b/spec/testreport_handler_spec.rb
@@ -96,7 +96,7 @@ describe TestReportHandler do
 
         it 'returns builder with report.setup' do
           builder = TestReportHandler::TestReportBuilder.new(@script)
-
+          builder.report.id = "[UUID]" # remove generated value
           expect(builder.report).to eq(@report_outline)
         end
       end
@@ -111,7 +111,7 @@ describe TestReportHandler do
 
         it 'returns builder with report.test' do
           builder = TestReportHandler::TestReportBuilder.new(@script)
-
+          builder.report.id = "[UUID]" # remove generated value
           expect(builder.report).to eq(@report_outline)
         end
       end
@@ -126,7 +126,7 @@ describe TestReportHandler do
 
         it 'returns builder with report.teardown' do
           builder = TestReportHandler::TestReportBuilder.new(@script)
-
+          builder.report.id = "[UUID]" # remove generated value
           expect(builder.report).to eq(@report_outline)
         end
       end
@@ -134,7 +134,7 @@ describe TestReportHandler do
       context 'with all script phases' do
         it 'returns builder with all report phases' do
           builder = TestReportHandler::TestReportBuilder.new(@script)
-
+          builder.report.id = "[UUID]" # remove generated value
           expect(builder.report).to eq(@report_outline)
         end
       end

--- a/spec/validate_profile_id_spec.rb
+++ b/spec/validate_profile_id_spec.rb
@@ -28,7 +28,7 @@ describe TestScriptRunnable do
         @assert.sourceId = 'patient_uscore'
         
         expect(@runnable.validate_profile_id(@assert))
-          .to eq(" As expected, fixture '#{@assert.sourceId}' conforms to profile: '#{@assert.validateProfileId}'")
+          .to eq("Fixture '#{@assert.sourceId}' conforms to profile '#{@assert.validateProfileId}'.")
           
       end
     end


### PR DESCRIPTION
# Summary

Improve the feedback mechanism for profile validation errors specifically, but also executions in general

## New behavior

- validate profile id success and failure messages include validation errors and warnings
- skip logic fixed to match TestScript spec
- TestReports exported to run-specific folder

## Testing guidance

`bundle exec bin/testscript_engine execute --config config-multipleMCODE.yml`
